### PR TITLE
[FIX] remove unnecessary comma in constructor

### DIFF
--- a/Classes/Command/ExportCommand.php
+++ b/Classes/Command/ExportCommand.php
@@ -71,7 +71,7 @@ class ExportCommand extends Command
     public function __construct(
         XliffService             $xliffService,
         ExportServiceFactory     $exportServiceFactory,
-        EventDispatcherInterface $eventDispatcher = null,
+        EventDispatcherInterface $eventDispatcher = null
     )
     {
         parent::__construct();


### PR DESCRIPTION
Remove the comma for PHP 8 support please.